### PR TITLE
Add mass deletetag feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.tag.Tag;
@@ -11,30 +13,33 @@ import seedu.address.model.tag.Tag;
  */
 public class DeleteTagCommand extends Command {
     public static final String COMMAND_WORD = "deletetag";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an existing tag (case insensitive).\n"
             + "Parameters: TAG_NAME (MAX 50 alphanumeric characters, spaces, parenthesis and apostrophes)\n"
-            + "Example: " + COMMAND_WORD + " Bride's Friend";
-    public static final String MESSAGE_SUCCESS = "Tag deleted: ";
-    public static final String MESSAGE_NONEXISTENT = "This tag does not exist yet.\n";
-    private final Tag tag;
+            + "Example: " + COMMAND_WORD + " t/bride's friend t/groom's friend";
+
+    public static final String MESSAGE_SUCCESS = "Tag(s) deleted: ";
+    public static final String YOUR_TAGS_PREFIX = "Your tags: ";
+    public static final String MESSAGE_NONEXISTENT = "Some tag(s) provided have not been added before.\n";
+    private final List<Tag> tags;
 
     /**
-     * @param tag The tag object to be added.
+     * @param tags The tag object to be added.
      */
-    public DeleteTagCommand(Tag tag) {
-        requireAllNonNull(tag);
-        this.tag = tag;
+    public DeleteTagCommand(List<Tag> tags) {
+        requireAllNonNull(tags);
+        this.tags = tags;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
-        boolean isSuccessful = model.deleteTag(tag);
+        boolean isSuccessful = model.deleteTags(tags);
         if (!isSuccessful) {
             throw new CommandException(MESSAGE_NONEXISTENT);
         }
-        String successMessage = MESSAGE_SUCCESS + " " + tag + "\n";
-        String currentTags = "Your tags: " + model.getTagList();
+        String successMessage = MESSAGE_SUCCESS + tags + "\n";
+        String currentTags = YOUR_TAGS_PREFIX + model.getTagList();
         return new CommandResult(successMessage + currentTags);
     }
 
@@ -49,6 +54,6 @@ public class DeleteTagCommand extends Command {
         }
 
         DeleteTagCommand otherCommand = (DeleteTagCommand) other;
-        return tag.equals(otherCommand.tag);
+        return tags.equals(otherCommand.tags);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -9,19 +9,19 @@ import seedu.address.model.tag.Tag;
 /**
  * Adds a new predefined tag.
  */
-public class NewtagCommand extends Command {
-    public static final String COMMAND_WORD = "newtag";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new tag (case insensitive).\n"
+public class DeleteTagCommand extends Command {
+    public static final String COMMAND_WORD = "deletetag";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an existing tag (case insensitive).\n"
             + "Parameters: TAG_NAME (MAX 50 alphanumeric characters, spaces, parenthesis and apostrophes)\n"
             + "Example: " + COMMAND_WORD + " Bride's Friend";
-    public static final String MESSAGE_SUCCESS = "New tag added: ";
-    public static final String MESSAGE_DUPLICATE = "This tag already exists.\n";
+    public static final String MESSAGE_SUCCESS = "Tag deleted: ";
+    public static final String MESSAGE_NONEXISTENT = "This tag does not exist yet.\n";
     private final Tag tag;
 
     /**
      * @param tag The tag object to be added.
      */
-    public NewtagCommand(Tag tag) {
+    public DeleteTagCommand(Tag tag) {
         requireAllNonNull(tag);
         this.tag = tag;
     }
@@ -29,9 +29,9 @@ public class NewtagCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
-        boolean isSuccessful = model.addTag(tag);
+        boolean isSuccessful = model.deleteTag(tag);
         if (!isSuccessful) {
-            throw new CommandException(MESSAGE_DUPLICATE);
+            throw new CommandException(MESSAGE_NONEXISTENT);
         }
         String successMessage = MESSAGE_SUCCESS + " " + tag + "\n";
         String currentTags = "Your tags: " + model.getTagList();
@@ -44,11 +44,11 @@ public class NewtagCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof NewtagCommand)) {
+        if (!(other instanceof DeleteTagCommand)) {
             return false;
         }
 
-        NewtagCommand otherCommand = (NewtagCommand) other;
+        DeleteTagCommand otherCommand = (DeleteTagCommand) other;
         return tag.equals(otherCommand.tag);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterCommand;
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case NewtagCommand.COMMAND_WORD:
             return new NewtagCommandParser().parse(arguments);
+
+        case DeleteTagCommand.COMMAND_WORD:
+            return new DeleteTagCommandParser().parse(arguments);
 
         case RsvpCommand.RSVP_COMMAND_WORD:
             return new RsvpCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -1,6 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,12 +20,13 @@ public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
     /**
      * Checks if a given string (trimmed) is a valid argument
      * for the DeleteTagCommand class.
+     * @param argument the argument to be checked.
      * @return true if it is valid, and false otherwise.
      */
-    public boolean isValidArguments(String trimmedArgs) {
-        boolean isEmpty = trimmedArgs.isEmpty();
-        boolean isTooLong = trimmedArgs.length() > MAX_LENGTH;
-        boolean isValidCharacters = trimmedArgs.matches(VALIDATION_REGEX);
+    public boolean isValidArgument(String argument) {
+        boolean isEmpty = argument.isEmpty();
+        boolean isTooLong = argument.length() > MAX_LENGTH;
+        boolean isValidCharacters = argument.matches(VALIDATION_REGEX);
         if (isEmpty || isTooLong || !isValidCharacters) {
             return false;
         }
@@ -34,13 +39,24 @@ public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
      * @throws ParseException if the user input does not conform to the expected format.
      */
     public DeleteTagCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim().toLowerCase();
+        String lowerCaseArguments = args.toLowerCase();
+        ArgumentMultimap tokenisedArguments = ArgumentTokenizer.tokenize(lowerCaseArguments, PREFIX_TAG);
+        List<String> arguments = tokenisedArguments.getAllValues(PREFIX_TAG);
+        List<Tag> tagsToDelete = new ArrayList<>();
 
-        if (!isValidArguments(trimmedArgs)) {
+        if (arguments.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
         }
 
-        Tag tag = new Tag(trimmedArgs);
-        return new DeleteTagCommand(tag);
+        for (String argument : arguments) {
+            if (!isValidArgument(argument)) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
+            }
+
+            Tag tag = new Tag(argument);
+            tagsToDelete.add(tag);
+        }
+
+        return new DeleteTagCommand(tagsToDelete);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -12,6 +12,22 @@ import seedu.address.model.tag.Tag;
 public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
     public static final int MAX_LENGTH = 50;
     public static final String VALIDATION_REGEX = "[\\p{Alnum}'() ]+";
+
+    /**
+     * Checks if a given string (trimmed) is a valid argument
+     * for the DeleteTagCommand class.
+     * @return true if it is valid, and false otherwise.
+     */
+    public boolean isValidArguments(String trimmedArgs) {
+        boolean isEmpty = trimmedArgs.isEmpty();
+        boolean isTooLong = trimmedArgs.length() > MAX_LENGTH;
+        boolean isValidCharacters = trimmedArgs.matches(VALIDATION_REGEX);
+        if (isEmpty || isTooLong || !isValidCharacters) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteTagCommand
      * and returns a DeleteTagCommand object for execution.
@@ -20,12 +36,7 @@ public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
     public DeleteTagCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim().toLowerCase();
 
-        // Check if the input is empty, exceeds the maximum length,
-        // or contains non-alphanumeric characters other than spaces.
-        boolean isEmpty = trimmedArgs.isEmpty();
-        boolean isTooLong = trimmedArgs.length() > MAX_LENGTH;
-        boolean isValidCharacters = trimmedArgs.matches(VALIDATION_REGEX);
-        if (isEmpty || isTooLong || !isValidCharacters) {
+        if (!isValidArguments(trimmedArgs)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.DeleteTagCommand;
-import seedu.address.logic.commands.NewtagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.logic.commands.NewtagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new DeleteTagCommand object.
+ */
+public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
+    public static final int MAX_LENGTH = 50;
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}'() ]+";
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteTagCommand
+     * and returns a DeleteTagCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public DeleteTagCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim().toLowerCase();
+
+        // Check if the input is empty, exceeds the maximum length,
+        // or contains non-alphanumeric characters other than spaces.
+        boolean isEmpty = trimmedArgs.isEmpty();
+        boolean isTooLong = trimmedArgs.length() > MAX_LENGTH;
+        boolean isValidCharacters = trimmedArgs.matches(VALIDATION_REGEX);
+        if (isEmpty || isTooLong || !isValidCharacters) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
+        }
+
+        Tag tag = new Tag(trimmedArgs);
+        return new DeleteTagCommand(tag);
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -114,6 +114,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         return true;
     }
 
+    /**
+     * Deletes {@code key} from this {@code AddressBook}.
+     * @param t The tag to be deleted.
+     */
+    public boolean deleteTag(Tag t) {
+        tags.deleteTag(t);
+        return true;
+    }
+
     public boolean hasTag(Tag t) {
         return tags.contains(t);
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -95,6 +95,14 @@ public interface Model {
     boolean addTag(Tag tag);
 
     /**
+     * Deletes a tag from the tag list.
+     *
+     * @param tag The tag to be deleted.
+     * @return true if the tag was successfully deleted, false if the tag does not exist.
+     */
+    boolean deleteTag(Tag tag);
+
+    /**
      * Checks if a tag exists in the tag list.
      *
      * @param tag The tag to check for existence.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -97,10 +98,10 @@ public interface Model {
     /**
      * Deletes a tag from the tag list.
      *
-     * @param tag The tag to be deleted.
+     * @param tags The tag to be deleted.
      * @return true if the tag was successfully deleted, false if the tag does not exist.
      */
-    boolean deleteTag(Tag tag);
+    boolean deleteTags(List<Tag> tags);
 
     /**
      * Checks if a tag exists in the tag list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -141,6 +141,16 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean deleteTag(Tag tag) {
+        if (!this.hasTag(tag)) {
+            return false;
+        }
+
+        addressBook.deleteTag(tag);
+        return true;
+    }
+
+    @Override
     public boolean hasTag(Tag tag) {
         return addressBook.hasTag(tag);
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -141,12 +142,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean deleteTag(Tag tag) {
-        if (!this.hasTag(tag)) {
-            return false;
+    public boolean deleteTags(List<Tag> tags) {
+        for (Tag tag : tags) {
+            if (!this.hasTag(tag)) {
+                return false;
+            }
+            addressBook.deleteTag(tag);
         }
-
-        addressBook.deleteTag(tag);
         return true;
     }
 

--- a/src/main/java/seedu/address/model/tag/TagList.java
+++ b/src/main/java/seedu/address/model/tag/TagList.java
@@ -28,6 +28,16 @@ public class TagList {
     }
 
     /**
+     * Deletes a tag if it is already present.
+     *
+     * @param tag The tag to delete.
+     * @return true if the tag was deleted, false if it does not exist.
+     */
+    public boolean deleteTag(Tag tag) {
+        return tags.remove(tag);
+    }
+
+    /**
      * Sets the TagList based on a list from Storage.
      *
      * @param tags The tags to add.

--- a/src/main/java/seedu/address/model/tag/TagList.java
+++ b/src/main/java/seedu/address/model/tag/TagList.java
@@ -61,6 +61,9 @@ public class TagList {
     }
     @Override
     public String toString() {
+        if (tags.isEmpty()) {
+            return "You have no tags.";
+        }
         return String.join(", ", tags.stream().map(Tag::getTagName).toList());
     }
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -170,6 +170,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean deleteTag(Tag tag) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasTag(Tag tag) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -170,7 +171,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean deleteTag(Tag tag) {
+        public boolean deleteTags(List<Tag> tag) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -4,6 +4,9 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalTags.VALID_TAG_BRIDES_FRIEND;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
@@ -21,9 +24,11 @@ public class DeleteTagCommandTest {
     @Test
     public void execute_existingTag_success() {
         Tag existingTag = VALID_TAG_BRIDES_FRIEND;
+        List<Tag> existingTags = new ArrayList<Tag>();
+        existingTags.add(existingTag);
         model.addTag(existingTag);
 
-        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(existingTag);
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(existingTags);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
@@ -36,8 +41,10 @@ public class DeleteTagCommandTest {
     @Test
     public void execute_nonExistentTag_failure() {
         Tag nonExistentTag = VALID_TAG_BRIDES_FRIEND;
+        List<Tag> nonExistentTags = new ArrayList<>();
+        nonExistentTags.add(nonExistentTag);
 
-        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(nonExistentTag);
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(nonExistentTags);
         String expectedMessage = DeleteTagCommand.MESSAGE_NONEXISTENT;
 
         assertCommandFailure(deleteTagCommand, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalTags.VALID_TAG_BRIDES_FRIEND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Contains tests for DeleteTagCommand.
+ */
+public class DeleteTagCommandTest {
+
+    private Model model = new ModelManager();
+
+    @Test
+    public void execute_existingTag_success() {
+        Tag existingTag = VALID_TAG_BRIDES_FRIEND;
+        model.addTag(existingTag);
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(existingTag);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS + " " + existingTag + "\n"
+                + "Your tags: ";
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_nonExistentTag_failure() {
+        Tag nonExistentTag = VALID_TAG_BRIDES_FRIEND;
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(nonExistentTag);
+        String expectedMessage = DeleteTagCommand.MESSAGE_NONEXISTENT;
+
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -32,8 +32,8 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS + " " + existingTag + "\n"
-                + "Your tags: ";
+        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS + "[" + existingTag + "]\n"
+                + "Your tags: You have no tags.";
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -23,7 +23,17 @@ public class DeleteTagCommandParserTest {
         Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
         List<Tag> expectedTags = new ArrayList<>();
         expectedTags.add(expectedTag);
-        assertParseSuccess(parser, "bride's friend", new DeleteTagCommand(expectedTags));
+        assertParseSuccess(parser, " t/bride's friend", new DeleteTagCommand(expectedTags));
+    }
+
+    @Test
+    public void parse_validArgsNoLeadingSpace_throwsParseException() {
+        assertParseFailure(parser, "t/bride's friend", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgsNoPrefix_throwsParseException() {
+        assertParseFailure(parser, "bride's friend", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test
@@ -31,25 +41,35 @@ public class DeleteTagCommandParserTest {
         Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
         List<Tag> expectedTags = new ArrayList<>();
         expectedTags.add(expectedTag);
-        assertParseSuccess(parser, "   bride's friend   ", new DeleteTagCommand(expectedTags));
+        assertParseSuccess(parser, "  t/ bride's friend   ", new DeleteTagCommand(expectedTags));
     }
 
     @Test
     public void parse_emptyArgs_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, " t/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_AtMaxLength_returnsDeleteTagCommand() {
+        String maxLengthTagName = "a".repeat(50); // 50 characters
+        Tag expectedTag = new Tag(maxLengthTagName);
+        List<Tag> expectedTags = new ArrayList<>();
+        expectedTags.add(expectedTag);
+
+        assertParseSuccess(parser, " t/" + maxLengthTagName, new DeleteTagCommand(expectedTags));
     }
 
     @Test
     public void parse_exceedsMaxLength_throwsParseException() {
-        String longTag = "a".repeat(51); // 51 characters, exceeding the 50-character limit.
-        assertParseFailure(parser, longTag, String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        String longTagName = "a".repeat(51); // 51 characters, exceeding the 50-character limit.
+        assertParseFailure(parser, " t/" + longTagName, String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidCharacters_throwsParseException() {
-        assertParseFailure(parser, ";%<>}{", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
-        assertParseFailure(parser, "¡£™", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
-        assertParseFailure(parser, "¶¢", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "t/;%<>}{", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "t/¡£™", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "t/¶¢", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test
@@ -57,6 +77,31 @@ public class DeleteTagCommandParserTest {
         Tag expectedTag = new Tag("friend");
         List<Tag> expectedTags = new ArrayList<>();
         expectedTags.add(expectedTag);
-        assertParseSuccess(parser, "  FRIEND  ", new DeleteTagCommand(expectedTags));
+        assertParseSuccess(parser, " t/FRIEND", new DeleteTagCommand(expectedTags));
+    }
+
+    @Test
+    public void parse_multipleValidArgs_returnsDeleteTagCommand() {
+        Tag expectedTagBride = TypicalTags.BRIDES_SIDE;
+        Tag expectedTagGroom = TypicalTags.GROOMS_SIDE;
+        List<Tag> expectedTags = new ArrayList<>();
+        expectedTags.add(expectedTagBride);
+        expectedTags.add(expectedTagGroom);
+        assertParseSuccess(parser, " t/bride's side t/groom's side", new DeleteTagCommand(expectedTags));
+    }
+
+    @Test
+    public void parse_multipleValidArgsWithoutSpace_returnsDeleteTagCommand() {
+        assertParseFailure(parser, " t/bride's sidet/groom's side", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleArgsOneInvalid_returnsDeleteTagCommand() {
+        assertParseFailure(parser, " t/bride's side t/^@%", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleArgsOneExceedsMaxLength_returnsDeleteTagCommand() {
+        assertParseFailure(parser, " t/bride's side t/" + "a".repeat(51), String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.TypicalTags;
+
+public class DeleteTagCommandParserTest {
+
+    private DeleteTagCommandParser parser = new DeleteTagCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteTagCommand() {
+        Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
+        assertParseSuccess(parser, "bride's friend", new DeleteTagCommand(expectedTag));
+    }
+
+    @Test
+    public void parse_leadingAndTrailingSpaces_returnsDeleteTagCommand() {
+        Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
+        assertParseSuccess(parser, "   bride's friend   ", new DeleteTagCommand(expectedTag));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_exceedsMaxLength_throwsParseException() {
+        String longTag = "a".repeat(51); // 51 characters, exceeding the 50-character limit.
+        assertParseFailure(parser, longTag, String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidCharacters_throwsParseException() {
+        assertParseFailure(parser, ";%<>}{", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "¡£™", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "¶¢", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_caseInsensitiveTag_returnsNewtagCommand() {
+        Tag expectedTag = new Tag("friend");
+        assertParseSuccess(parser, "  FRIEND  ", new DeleteTagCommand(expectedTag));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -50,7 +50,7 @@ public class DeleteTagCommandParserTest {
     }
 
     @Test
-    public void parse_AtMaxLength_returnsDeleteTagCommand() {
+    public void parse_maxLength_returnsDeleteTagCommand() {
         String maxLengthTagName = "a".repeat(50); // 50 characters
         Tag expectedTag = new Tag(maxLengthTagName);
         List<Tag> expectedTags = new ArrayList<>();

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -5,6 +5,9 @@ import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteTagCommand;
@@ -18,13 +21,17 @@ public class DeleteTagCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteTagCommand() {
         Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
-        assertParseSuccess(parser, "bride's friend", new DeleteTagCommand(expectedTag));
+        List<Tag> expectedTags = new ArrayList<>();
+        expectedTags.add(expectedTag);
+        assertParseSuccess(parser, "bride's friend", new DeleteTagCommand(expectedTags));
     }
 
     @Test
     public void parse_leadingAndTrailingSpaces_returnsDeleteTagCommand() {
         Tag expectedTag = TypicalTags.VALID_TAG_BRIDES_FRIEND;
-        assertParseSuccess(parser, "   bride's friend   ", new DeleteTagCommand(expectedTag));
+        List<Tag> expectedTags = new ArrayList<>();
+        expectedTags.add(expectedTag);
+        assertParseSuccess(parser, "   bride's friend   ", new DeleteTagCommand(expectedTags));
     }
 
     @Test
@@ -48,6 +55,8 @@ public class DeleteTagCommandParserTest {
     @Test
     public void parse_caseInsensitiveTag_returnsNewtagCommand() {
         Tag expectedTag = new Tag("friend");
-        assertParseSuccess(parser, "  FRIEND  ", new DeleteTagCommand(expectedTag));
+        List<Tag> expectedTags = new ArrayList<>();
+        expectedTags.add(expectedTag);
+        assertParseSuccess(parser, "  FRIEND  ", new DeleteTagCommand(expectedTags));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -92,16 +92,19 @@ public class DeleteTagCommandParserTest {
 
     @Test
     public void parse_multipleValidArgsWithoutSpace_returnsDeleteTagCommand() {
-        assertParseFailure(parser, " t/bride's sidet/groom's side", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, " t/bride's sidet/groom's side",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test
     public void parse_multipleArgsOneInvalid_returnsDeleteTagCommand() {
-        assertParseFailure(parser, " t/bride's side t/^@%", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, " t/bride's side t/^@%",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test
     public void parse_multipleArgsOneExceedsMaxLength_returnsDeleteTagCommand() {
-        assertParseFailure(parser, " t/bride's side t/" + "a".repeat(51), String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, " t/bride's side t/" + "a".repeat(51),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -104,6 +104,13 @@ public class AddressBookTest {
     }
 
     @Test
+    public void deleteTag_tagInList_returnsFalse() {
+        Tag tag = new Tag(VALID_TAG_HUSBAND);
+        addressBook.deleteTag(tag);
+        assertFalse(addressBook.hasTag(tag));
+    }
+
+    @Test
     public void hasTag_tagNotInList_returnsFalse() {
         Tag tag = new Tag(VALID_TAG_HUSBAND);
         assertFalse(addressBook.hasTag(tag));
@@ -113,6 +120,13 @@ public class AddressBookTest {
     public void hasTag_tagInList_returnsTrue() {
         Tag tag = new Tag(VALID_TAG_HUSBAND);
         addressBook.addTag(tag);
+        assertTrue(addressBook.hasTag(tag));
+    }
+
+    @Test
+    public void hasTag_tagWithTheSameNameInAddressBook_returnsTrue() {
+        Tag tag = new Tag(VALID_TAG_HUSBAND);
+        addressBook.addTag(new Tag(VALID_TAG_HUSBAND));
         assertTrue(addressBook.hasTag(tag));
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -152,5 +152,4 @@ public class AddressBookTest {
             return tags;
         }
     }
-
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalTags.COLLEAGUES;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalTags.COLLEAGUES;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalTags.COLLEAGUES;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
@@ -93,6 +94,16 @@ public class ModelManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }
 
+    @Test
+    public void hasTag_tagInAddressBook_returnsTrue() {
+        modelManager.addTag(COLLEAGUES);
+        assertTrue(modelManager.hasTag(COLLEAGUES));
+    }
+
+    @Test
+    public void hasTag_tagNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasTag(COLLEAGUES));
+    }
     @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();

--- a/src/test/java/seedu/address/model/tag/TagListTest.java
+++ b/src/test/java/seedu/address/model/tag/TagListTest.java
@@ -23,25 +23,36 @@ public class TagListTest {
 
     @Test
     public void addTag_newTag_success() {
-        assertTrue(tagList.addTag(tag1)); // Tag should be added.
-        assertTrue(tagList.contains(tag1)); // Tag should be present in the list.
+        assertTrue(tagList.addTag(tag1));
+        assertTrue(tagList.contains(tag1));
     }
 
     @Test
     public void addTag_duplicateTag_failure() {
         tagList.addTag(tag1);
-        assertFalse(tagList.addTag(tag1)); // Adding the same tag again should return false.
+        assertFalse(tagList.addTag(tag1));
+    }
+
+    @Test
+    public void deleteTag_existingTag_success() {
+        tagList.addTag(tag1);
+        assertTrue(tagList.deleteTag(tag1));
+    }
+
+    @Test
+    public void deleteTag_nonExistentTag_failure() {
+        assertFalse(tagList.deleteTag(tag1));
     }
 
     @Test
     public void contains_tagInList_success() {
         tagList.addTag(tag2);
-        assertTrue(tagList.contains(tag2)); // Tag should be found in the list.
+        assertTrue(tagList.contains(tag2));
     }
 
     @Test
     public void contains_tagNotInList_failure() {
-        assertFalse(tagList.contains(tag3)); // Tag should not be found in the empty list.
+        assertFalse(tagList.contains(tag3));
     }
 
     @Test


### PR DESCRIPTION
- `deletetag` command format changed to: `deletetag /t tag1 /t tag2` to enable mass deletion