### PR TITLE
Bulk untagging for multiple guests and multiple tags

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -11,6 +11,8 @@ import seedu.address.commons.util.ToStringBuilder;
  * convert it back to an int if the index will not be passed to a different component again.
  */
 public class Index {
+    public static final int MAX_INDEXES = 10;
+
     private int zeroBasedIndex;
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_INPUT_LENGTH_EXCEEDED = "The input length cannot exceed 50 characters";
+    public static final String MESSAGE_INPUT_LENGTH_EXCEEDED = "The tag length cannot exceed %d characters.";
     public static final String MESSAGE_TOO_MANY_INDEXES = "The number of target guests cannot exceed %d.";
 
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
 import java.util.List;
@@ -17,12 +18,14 @@ import seedu.address.model.tag.Tag;
 public class DeleteTagCommand extends Command {
     public static final String COMMAND_WORD = "deletetag";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an existing tag (case insensitive).\n"
-            + "Parameters: TAG_NAME (MAX 50 alphanumeric characters, spaces, parenthesis and apostrophes)\n"
-            + "Example: " + COMMAND_WORD + " t/bride's friend t/groom's friend";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes existing tag(s) in tag list(case insensitive). Maximum of 50 alphanumeric characters,"
+            + "spaces, parenthesis and apostrophes per tag.\n"
+            + "Parameters: " + PREFIX_TAG + "TAG...\n"
+            + "Example: " + COMMAND_WORD + " t/bride's side t/groom's side";
 
     public static final String MESSAGE_SUCCESS = "Tag(s) deleted: ";
-    public static final String YOUR_TAGS_PREFIX = "Your tags: ";
+    public static final String MESSAGE_TAGLIST_PREFIX = "Your tags: ";
     public static final String MESSAGE_NONEXISTENT = "Some tag(s) provided have not been added before.\n";
     private final List<Tag> tags;
 
@@ -47,7 +50,7 @@ public class DeleteTagCommand extends Command {
         }
 
         String successMessage = MESSAGE_SUCCESS + tags + "\n";
-        String currentTags = YOUR_TAGS_PREFIX + model.getTagList();
+        String currentTags = MESSAGE_TAGLIST_PREFIX + model.getTagList();
         return new CommandResult(successMessage + currentTags);
     }
 

--- a/src/main/java/seedu/address/logic/commands/NewtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewtagCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
 
@@ -14,14 +15,17 @@ import seedu.address.model.tag.TagList;
  */
 public class NewtagCommand extends Command {
     public static final String COMMAND_WORD = "newtag";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new tag (case insensitive).\n"
-            + "Parameters: TAG_NAME (MAX 50 alphanumeric characters, spaces, parenthesis and apostrophes)\n"
-            + "Example: " + COMMAND_WORD + " t/Bride's Friend";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Creates new tag(s) (case insensitive). Maximum of 50 alphanumeric characters, spaces, parenthesis "
+            + "and apostrophes per tag.\n"
+            + "Parameters: " + PREFIX_TAG + "TAG...\n"
+            + "Example: " + COMMAND_WORD + " t/bride's side t/groom's side";
 
-    public static final String MESSAGE_SUCCESS = "New tag added: ";
-    public static final String MESSAGE_DUPLICATE = "This tag already exists.\n";
+    public static final String MESSAGE_SUCCESS = "New tag(s) created: ";
+    public static final String MESSAGE_DUPLICATE = "Some tag(s) already exists.\n";
+    public static final String MESSAGE_TAGLIST_PREFIX = "Your tags: ";
     public static final String MESSAGE_TOO_MANY_TAGS = "You have more than " + TagList.MAXIMUM_TAGLIST_SIZE
-            + " tags.\nPlease remove some using deletetag.\n";
+            + " tags.\nPlease remove some using 'deletetag'.\n";
 
     private final List<Tag> tags;
 
@@ -50,7 +54,7 @@ public class NewtagCommand extends Command {
 
         model.updateTagList();
 
-        String currentTags = "Your tags: " + model.getTagList();
+        String currentTags = MESSAGE_TAGLIST_PREFIX + model.getTagList();
         return new CommandResult(successMessage + currentTags);
     }
 

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -67,7 +67,7 @@ public class TagCommand extends Command {
             }
             Person personToTag = lastShownList.get(targetIndex.getZeroBased());
             Set<Tag> newTags = new HashSet<>(personToTag.getTags());
-            boolean updated = false;
+            boolean isUpdated = false;
 
             for (Tag tag : tags) {
                 if (!model.hasTag(tag)) {
@@ -76,42 +76,20 @@ public class TagCommand extends Command {
                     duplicateTags.add(tag);
                 } else {
                     newTags.add(tag);
-                    updated = true;
+                    isUpdated = true;
                 }
             }
 
-            if (updated) {
-                Person updatedPerson = new Person(personToTag.getName(), personToTag.getPhone(),
-                        personToTag.getEmail(), personToTag.getRsvpStatus(), newTags);
-                model.setPerson(personToTag, updatedPerson);
-                if (!successMessage.isEmpty()) {
-                    successMessage.append("\n");
-                }
-                successMessage.append(Messages.format(updatedPerson));
+            if (isUpdated) {
+                Person updatedPerson = setPerson(model, personToTag, newTags);
+                updateSuccessMessage(successMessage, updatedPerson);
             }
         }
         if (!successMessage.isEmpty()) {
             finalMessage.append(MESSAGE_TAG_PERSON_SUCCESS).append(successMessage);
         }
         if (!missingTags.isEmpty() || !duplicateTags.isEmpty()) {
-            if (!finalMessage.isEmpty()) {
-                finalMessage.append("\n");
-            }
-            if (!missingTags.isEmpty()) {
-                finalMessage.append(MESSAGE_TAG_NOT_CREATED)
-                        .append(missingTags.stream()
-                                .map(Tag::toString)
-                                .collect(Collectors.joining(", ")));
-            }
-            if (!duplicateTags.isEmpty()) {
-                if (!missingTags.isEmpty()) {
-                    finalMessage.append("\n");
-                }
-                finalMessage.append(MESSAGE_DUPLICATE_TAG)
-                        .append(duplicateTags.stream()
-                                .map(Tag::toString)
-                                .collect(Collectors.joining(", ")));
-            }
+            updateFinalMessage(finalMessage, duplicateTags, missingTags);
         }
         return new CommandResult(finalMessage.toString());
     }
@@ -137,5 +115,40 @@ public class TagCommand extends Command {
                 .add("targetIndexes", targetIndexes)
                 .add("tags", tags)
                 .toString();
+    }
+
+    private Person setPerson(Model model, Person personToTag, Set<Tag> newTags) {
+        Person updatedPerson = new Person(personToTag.getName(), personToTag.getPhone(),
+                personToTag.getEmail(), personToTag.getRsvpStatus(), newTags);
+        model.setPerson(personToTag, updatedPerson);
+        return updatedPerson;
+    }
+
+    private void updateSuccessMessage(StringBuilder successMessage, Person updatedPerson) {
+        if (!successMessage.isEmpty()) {
+            successMessage.append("\n");
+        }
+        successMessage.append(Messages.format(updatedPerson));
+    }
+
+    private void updateFinalMessage(StringBuilder finalMessage, Set<Tag> duplicateTags, Set<Tag> missingTags) {
+        if (!finalMessage.isEmpty()) {
+            finalMessage.append("\n");
+        }
+        if (!missingTags.isEmpty()) {
+            finalMessage.append(MESSAGE_TAG_NOT_CREATED)
+                    .append(missingTags.stream()
+                            .map(Tag::toString)
+                            .collect(Collectors.joining(", ")));
+        }
+        if (!duplicateTags.isEmpty()) {
+            if (!missingTags.isEmpty()) {
+                finalMessage.append("\n");
+            }
+            finalMessage.append(MESSAGE_DUPLICATE_TAG)
+                    .append(duplicateTags.stream()
+                            .map(Tag::toString)
+                            .collect(Collectors.joining(", ")));
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -24,12 +24,13 @@ public class TagCommand extends Command {
     public static final String COMMAND_WORD = "tag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Tags the guest identified by the index number used in the displayed guest list "
-                + "with predefined tag(s). \n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Tags the guest(s) identified by the index number(s) used in the displayed guest list "
+                + "with the predefined tag(s). \n"
+            + "Parameters: INDEX... (must be a positive integer(s))\n"
             + "[" + PREFIX_TAG + "TAG]... (must be created using 'newtag' command first)\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TAG + "bride's side";
+            + "Example: " + COMMAND_WORD + " 1 2 "
+            + PREFIX_TAG + "bride's side" + " "
+            + PREFIX_TAG + "groom's side";
 
     public static final String MESSAGE_TAG_PERSON_SUCCESS = "Tagged guest(s):\n";
     public static final String MESSAGE_TAG_NOT_CREATED = "Tag(s) must be created first using 'newtag' command: ";
@@ -39,8 +40,8 @@ public class TagCommand extends Command {
     private final Set<Tag> tags;
 
     /**
-     * @param targetIndexes of the person in the filtered person list to tag
-     * @param tags set of tags to tag the person with
+     * @param targetIndexes of the guest in the filtered person list to tag
+     * @param tags set of tags to tag the guest with
      */
     public TagCommand(List<Index> targetIndexes, Set<Tag> tags) {
         requireNonNull(targetIndexes);

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -65,38 +65,27 @@ public class UntagCommand extends Command {
             }
             Person personToUntag = lastShownList.get(targetIndex.getZeroBased());
             Set<Tag> newTags = new HashSet<>(personToUntag.getTags());
-            boolean updated = false;
+            boolean isUpdated = false;
 
             for (Tag tag : tags) {
                 if (!newTags.contains(tag)) {
                     missingTags.add(tag);
                 } else {
                     newTags.remove(tag);
-                    updated = true;
+                    isUpdated = true;
                 }
             }
 
-            if (updated) {
-                Person updatedPerson = new Person(personToUntag.getName(), personToUntag.getPhone(),
-                        personToUntag.getEmail(), personToUntag.getRsvpStatus(), newTags);
-                model.setPerson(personToUntag, updatedPerson);
-                if (!successMessage.isEmpty()) {
-                    successMessage.append("\n");
-                }
-                successMessage.append(Messages.format(updatedPerson));
+            if (isUpdated) {
+                Person updatedPerson = setPerson(model, personToUntag, newTags);
+                updateSuccessMessage(successMessage, updatedPerson);
             }
         }
         if (!successMessage.isEmpty()) {
             finalMessage.append(MESSAGE_UNTAG_PERSON_SUCCESS).append(successMessage);
         }
         if (!missingTags.isEmpty()) {
-            if (!finalMessage.isEmpty()) {
-                finalMessage.append("\n");
-            }
-            finalMessage.append(MESSAGE_TAG_NOT_FOUND)
-                    .append(missingTags.stream()
-                            .map(Tag::toString)
-                            .collect(Collectors.joining(", ")));
+            updateFinalMessage(finalMessage, missingTags);
         }
         return new CommandResult(finalMessage.toString());
     }
@@ -122,5 +111,29 @@ public class UntagCommand extends Command {
                 .add("targetIndexes", targetIndexes)
                 .add("tag", tags)
                 .toString();
+    }
+
+    private Person setPerson(Model model, Person personToUntag, Set<Tag> newTags) {
+        Person updatedPerson = new Person(personToUntag.getName(), personToUntag.getPhone(),
+                personToUntag.getEmail(), personToUntag.getRsvpStatus(), newTags);
+        model.setPerson(personToUntag, updatedPerson);
+        return updatedPerson;
+    }
+
+    private void updateSuccessMessage(StringBuilder successMessage, Person updatedPerson) {
+        if (!successMessage.isEmpty()) {
+            successMessage.append("\n");
+        }
+        successMessage.append(Messages.format(updatedPerson));
+    }
+
+    private void updateFinalMessage(StringBuilder finalMessage, Set<Tag> missingTags) {
+        if (!finalMessage.isEmpty()) {
+            finalMessage.append("\n");
+        }
+        finalMessage.append(MESSAGE_TAG_NOT_FOUND)
+                .append(missingTags.stream()
+                        .map(Tag::toString)
+                        .collect(Collectors.joining(", ")));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/NewtagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NewtagCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.NewtagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
@@ -14,7 +15,6 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new NewtagCommand object.
  */
 public class NewtagCommandParser implements Parser<NewtagCommand> {
-    public static final int MAX_LENGTH = 50;
     public static final String VALIDATION_REGEX = "[\\p{Alnum}' ]+";
 
     /**
@@ -25,7 +25,7 @@ public class NewtagCommandParser implements Parser<NewtagCommand> {
      */
     public boolean isValidArgument(String argument) {
         boolean isEmpty = argument.isEmpty();
-        boolean isTooLong = argument.length() > MAX_LENGTH;
+        boolean isTooLong = argument.length() > Index.MAX_INDEXES;
         boolean isValidCharacters = argument.matches(VALIDATION_REGEX);
         if (isEmpty || isTooLong || !isValidCharacters) {
             return false;

--- a/src/main/java/seedu/address/logic/parser/NewtagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NewtagCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.ArrayList;
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.NewtagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
@@ -25,7 +24,7 @@ public class NewtagCommandParser implements Parser<NewtagCommand> {
      */
     public boolean isValidArgument(String argument) {
         boolean isEmpty = argument.isEmpty();
-        boolean isTooLong = argument.length() > Index.MAX_INDEXES;
+        boolean isTooLong = argument.length() > Tag.MAX_CHARACTER_LENGTH;
         boolean isValidCharacters = argument.matches(VALIDATION_REGEX);
         if (isEmpty || isTooLong || !isValidCharacters) {
             return false;

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -19,8 +19,7 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new TagCommand object
  */
 public class TagCommandParser implements Parser<TagCommand> {
-    public static final int MAX_LENGTH = 50;
-    public static final int MAX_INDEXES = 10;
+    public static final String VALIDATION_REGEX = "\\d+";
 
     /**
      * Parses the given {@code String} of arguments in the context of the TagCommand
@@ -40,7 +39,8 @@ public class TagCommandParser implements Parser<TagCommand> {
 
         try {
             List<String> indexStrings = List.of(argMultimap.getPreamble().trim().split("\\s+"));
-            if (indexStrings.size() == 1 && indexStrings.get(0).isEmpty()) {
+            boolean isValidIndexes = indexStrings.size() != 1 || !indexStrings.get(0).isEmpty();
+            if (!isValidIndexes) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
             }
             checkIndexLength(indexStrings);
@@ -58,11 +58,12 @@ public class TagCommandParser implements Parser<TagCommand> {
         for (String tagString : tagStrings) {
             tagString = tagString.trim().toLowerCase();
             boolean isEmpty = tagString.isEmpty();
-            boolean isTooLong = tagString.length() > MAX_LENGTH;
+            boolean isTooLong = tagString.length() > Tag.MAX_CHARACTER_LENGTH;
             if (isEmpty) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
             } else if (isTooLong) {
-                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH));
+                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED,
+                        Tag.MAX_CHARACTER_LENGTH));
             }
             tagSet.add(new Tag(tagString));
         }
@@ -71,15 +72,15 @@ public class TagCommandParser implements Parser<TagCommand> {
     }
 
     private void checkIndex(String indexStr) throws ParseException {
-        if (!indexStr.matches("\\d+")) {
+        if (!indexStr.matches(VALIDATION_REGEX)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     TagCommand.MESSAGE_USAGE));
         }
     }
 
     private void checkIndexLength(List<String> indexStrings) throws ParseException {
-        if (indexStrings.size() > MAX_INDEXES) {
-            throw new ParseException(String.format(Messages.MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
+        if (indexStrings.size() > Index.MAX_INDEXES) {
+            throw new ParseException(String.format(Messages.MESSAGE_TOO_MANY_INDEXES, Index.MAX_INDEXES));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -40,7 +40,6 @@ public class TagCommandParser implements Parser<TagCommand> {
 
         try {
             List<String> indexStrings = List.of(argMultimap.getPreamble().trim().split("\\s+"));
-            System.out.println(indexStrings.isEmpty() + indexStrings.toString() + indexStrings.size());
             if (indexStrings.size() == 1 && indexStrings.get(0).isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
             }
@@ -63,7 +62,7 @@ public class TagCommandParser implements Parser<TagCommand> {
             if (isEmpty) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
             } else if (isTooLong) {
-                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED));
+                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH));
             }
             tagSet.add(new Tag(tagString));
         }

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -19,8 +19,7 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new UntagCommand object
  */
 public class UntagCommandParser implements Parser<UntagCommand> {
-    public static final int MAX_LENGTH = 50;
-    public static final int MAX_INDEXES = 10;
+    public static final String VALIDATION_REGEX = "\\d+";
 
     /**
      * Parses the given {@code String} of arguments in the context of the UntagCommand
@@ -40,17 +39,12 @@ public class UntagCommandParser implements Parser<UntagCommand> {
 
         try {
             List<String> indexStrings = List.of(argMultimap.getPreamble().trim().split("\\s+"));
-            if (indexStrings.size() == 1 && indexStrings.get(0).isEmpty()) {
+            boolean isValidIndexes = indexStrings.size() != 1 || !indexStrings.get(0).isEmpty();
+            if (!isValidIndexes) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
             }
             checkIndexLength(indexStrings);
-
-            for (String indexStr : indexStrings) {
-                if (!indexStr.isEmpty()) {
-                    checkIndex(indexStr);
-                    indexSet.add(ParserUtil.parseIndex(indexStr.trim()));
-                }
-            }
+            addIndexToSet(indexStrings, indexSet);
         } catch (NumberFormatException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
         }
@@ -58,11 +52,12 @@ public class UntagCommandParser implements Parser<UntagCommand> {
         for (String tagString : tagStrings) {
             tagString = tagString.trim().toLowerCase();
             boolean isEmpty = tagString.isEmpty();
-            boolean isTooLong = tagString.length() > MAX_LENGTH;
+            boolean isTooLong = tagString.length() > Tag.MAX_CHARACTER_LENGTH;
             if (isEmpty) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
             } else if (isTooLong) {
-                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH));
+                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED,
+                        Tag.MAX_CHARACTER_LENGTH));
             }
             tagSet.add(new Tag(tagString));
         }
@@ -71,15 +66,24 @@ public class UntagCommandParser implements Parser<UntagCommand> {
     }
 
     private void checkIndex(String indexStr) throws ParseException {
-        if (!indexStr.matches("\\d+")) {
+        if (!indexStr.matches(VALIDATION_REGEX)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UntagCommand.MESSAGE_USAGE));
         }
     }
 
     private void checkIndexLength(List<String> indexStrings) throws ParseException {
-        if (indexStrings.size() > MAX_INDEXES) {
-            throw new ParseException(String.format(Messages.MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
+        if (indexStrings.size() > Index.MAX_INDEXES) {
+            throw new ParseException(String.format(Messages.MESSAGE_TOO_MANY_INDEXES, Index.MAX_INDEXES));
+        }
+    }
+
+    private void addIndexToSet(List<String> indexStrings, Set<Index> indexSet) throws ParseException {
+        for (String indexStr : indexStrings) {
+            if (!indexStr.isEmpty()) {
+                checkIndex(indexStr);
+                indexSet.add(ParserUtil.parseIndex(indexStr.trim()));
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -4,6 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UntagCommand;
@@ -15,42 +20,66 @@ import seedu.address.model.tag.Tag;
  */
 public class UntagCommandParser implements Parser<UntagCommand> {
     public static final int MAX_LENGTH = 50;
+    public static final int MAX_INDEXES = 10;
 
     /**
-     * Parses the given {@code String} of arguments in the context of the TagCommand
-     * and returns a TagCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the UntagCommand
+     * and returns a UntagCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public UntagCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
-        Index index;
+        Set<Index> indexSet = new HashSet<>();
+        Set<Tag> tagSet = new HashSet<>();
+        List<String> tagStrings = argMultimap.getAllValues(PREFIX_TAG);
+        if (tagStrings.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
+        }
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE), pe);
-        }
+            List<String> indexStrings = List.of(argMultimap.getPreamble().trim().split("\\s+"));
+            if (indexStrings.size() == 1 && indexStrings.get(0).isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
+            }
+            checkIndexLength(indexStrings);
 
-        if (!argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            for (String indexStr : indexStrings) {
+                if (!indexStr.isEmpty()) {
+                    checkIndex(indexStr);
+                    indexSet.add(ParserUtil.parseIndex(indexStr.trim()));
+                }
+            }
+        } catch (NumberFormatException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
         }
 
-        String trimmedTagName = argMultimap.getValue(PREFIX_TAG).get().trim().toLowerCase();
-        boolean isEmpty = trimmedTagName.isEmpty();
-        boolean isTooLong = trimmedTagName.length() > MAX_LENGTH;
-
-        if (isEmpty) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
+        for (String tagString : tagStrings) {
+            tagString = tagString.trim().toLowerCase();
+            boolean isEmpty = tagString.isEmpty();
+            boolean isTooLong = tagString.length() > MAX_LENGTH;
+            if (isEmpty) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
+            } else if (isTooLong) {
+                throw new ParseException(String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH));
+            }
+            tagSet.add(new Tag(tagString));
         }
 
-        if (isTooLong) {
-            throw new ParseException(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED);
+        return new UntagCommand(new ArrayList<>(indexSet), tagSet);
+    }
+
+    private void checkIndex(String indexStr) throws ParseException {
+        if (!indexStr.matches("\\d+")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    UntagCommand.MESSAGE_USAGE));
         }
+    }
 
-        Tag tag = new Tag(trimmedTagName); // will need to edit this when combining newtag function
-
-        return new UntagCommand(index, tag);
+    private void checkIndexLength(List<String> indexStrings) throws ParseException {
+        if (indexStrings.size() > MAX_INDEXES) {
+            throw new ParseException(String.format(Messages.MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTags.BRIDES_SIDE;
+import static seedu.address.testutil.TypicalTags.FRIENDS;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -107,7 +108,7 @@ public class TagCommandTest {
     @Test
     public void execute_bulkTagging_someGuestsAlreadyHaveTagReportsProperly() {
         // Guests at indexes 1 and 2 has the tag "friends", but guest at index 3 does not
-        Tag friendTag = new Tag("friends");
+        Tag friendTag = FRIENDS;
         model.addTag(friendTag);
         assertTrue(model.hasTag(friendTag));
 
@@ -136,7 +137,7 @@ public class TagCommandTest {
     @Test
     public void execute_bulkTagging_someTagsNotCreatedReportsProperly() {
         // Tags "bride's side" and "friends" are created, but not "nonexistent" tag
-        Tag friendTag = new Tag("friends");
+        Tag friendTag = FRIENDS;
         Tag nonExistentTag = new Tag("nonexistent");
         model.addTag(friendTag);
         assertTrue(model.hasTag(BRIDES_SIDE));

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -4,13 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTags.BRIDES_SIDE;
+import static seedu.address.testutil.TypicalTags.FRIENDS;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.RsvpStatus;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -36,7 +40,12 @@ public class UntagCommandTest {
         Tag tag = new Tag("friends");
         Person personToUntag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         assertTrue(personToUntag.getTags().contains(tag));
-        UntagCommand untagCommand = new UntagCommand(INDEX_FIRST_PERSON, tag);
+
+        Set<Tag> tags = new HashSet<>();
+        List<Index> indexes = new ArrayList<>();
+        tags.add(tag);
+        indexes.add(INDEX_FIRST_PERSON);
+        UntagCommand untagCommand = new UntagCommand(indexes, tags);
 
         Set<Tag> updatedTags = new HashSet<>(personToUntag.getTags());
         updatedTags.remove(tag);
@@ -52,47 +61,118 @@ public class UntagCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToUntag, modifiedPerson);
 
-        String expectedMessage = String.format(UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS,
-                Messages.format(modifiedPerson));
+        String expectedMessage = UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS + Messages.format(modifiedPerson);
 
         assertCommandSuccess(untagCommand, model, expectedMessage, expectedModel);
         assertFalse(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())
-                        .getTags().contains(BRIDES_SIDE));
+                        .getTags().contains(tag));
+    }
+
+    @Test
+    public void execute_tagExistsAndOnMultiplePersons_success() {
+        Tag tag = new Tag("friends");
+        Person firstPersonToTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToTag = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        assertTrue(firstPersonToTag.getTags().contains(tag));
+        assertTrue(secondPersonToTag.getTags().contains(tag));
+
+        Set<Tag> tags = new HashSet<>();
+        List<Index> indexes = new ArrayList<>();
+        tags.add(tag);
+        indexes.add(INDEX_FIRST_PERSON);
+        indexes.add(INDEX_SECOND_PERSON);
+        UntagCommand untagCommand = new UntagCommand(indexes, tags);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Set<Tag> firstPersonUpdatedTags = new HashSet<>(firstPersonToTag.getTags());
+        firstPersonUpdatedTags.remove(tag);
+        Set<Tag> secondPersonUpdatedTags = new HashSet<>(secondPersonToTag.getTags());
+        secondPersonUpdatedTags.remove(tag);
+
+        Person firstUpdatedPerson = new Person(firstPersonToTag.getName(), firstPersonToTag.getPhone(),
+                firstPersonToTag.getEmail(), RsvpStatus.PENDING, firstPersonUpdatedTags);
+        expectedModel.setPerson(firstPersonToTag, firstUpdatedPerson);
+
+        Person secondUpdatedPerson = new Person(secondPersonToTag.getName(), secondPersonToTag.getPhone(),
+                secondPersonToTag.getEmail(), RsvpStatus.PENDING, secondPersonUpdatedTags);
+        expectedModel.setPerson(secondPersonToTag, secondUpdatedPerson);
+        String expectedMessage = UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS
+                + Messages.format(firstUpdatedPerson) + "\n"
+                + Messages.format(secondUpdatedPerson);
+
+        assertCommandSuccess(untagCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        UntagCommand untagCommand = new UntagCommand(outOfBoundIndex, BRIDES_SIDE);
+        List<Index> indexList = new ArrayList<>();
+        indexList.add(outOfBoundIndex);
+        Set<Tag> tags = new HashSet<>();
+        tags.add(BRIDES_SIDE);
+        UntagCommand untagCommand = new UntagCommand(indexList, tags);
 
         assertCommandFailure(untagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
-    public void execute_tagNotFound_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_bulkUntagging_someTagsNotFoundReportsProperly() {
+        // Tags "friends" are on guests at indexes 1 and 2, but 3
+        Tag friendTag = FRIENDS;
 
-        Person personToUntag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        List<Index> indexes = List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON);
+        Set<Tag> tags = new HashSet<>();
+        tags.add(friendTag);
+        UntagCommand untagCommand = new UntagCommand(indexes, tags);
 
-        Set<Tag> initialTags = new HashSet<>(personToUntag.getTags());
-        initialTags.remove(new Tag("nonexistenttag"));
+        Person firstPersonToUntag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToUntag = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Set<Tag> firstPersonUpdatedTags = new HashSet<>(firstPersonToUntag.getTags());
+        firstPersonUpdatedTags.remove(friendTag);
+        Set<Tag> secondPersonUpdatedTags = new HashSet<>(secondPersonToUntag.getTags());
+        secondPersonUpdatedTags.remove(friendTag);
 
-        UntagCommand untagCommand = new UntagCommand(INDEX_FIRST_PERSON, new Tag("nonexistenttag"));
-        assertCommandFailure(untagCommand, model, UntagCommand.MESSAGE_TAG_NOT_FOUND);
+        Person firstUpdatedPerson = new Person(firstPersonToUntag.getName(), firstPersonToUntag.getPhone(),
+                firstPersonToUntag.getEmail(), RsvpStatus.PENDING, firstPersonUpdatedTags);
+        expectedModel.setPerson(firstPersonToUntag, firstUpdatedPerson);
+        Person secondUpdatedPerson = new Person(secondPersonToUntag.getName(), secondPersonToUntag.getPhone(),
+                secondPersonToUntag.getEmail(), RsvpStatus.PENDING, secondPersonUpdatedTags);
+        expectedModel.setPerson(secondPersonToUntag, secondUpdatedPerson);
+        String expectedSuccessMessage = UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS + Messages.format(firstUpdatedPerson)
+                + "\n" + Messages.format(secondUpdatedPerson);
+        String expectedTagNotFoundMessage = UntagCommand.MESSAGE_TAG_NOT_FOUND + friendTag;
+
+        String expectedMessage = expectedSuccessMessage + "\n" + expectedTagNotFoundMessage;
+
+        assertCommandSuccess(untagCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void equals() {
         Tag anotherTag = new Tag("anotherTag");
-        UntagCommand untagFirstCommand = new UntagCommand(INDEX_FIRST_PERSON, BRIDES_SIDE);
-        UntagCommand untagSecondCommand = new UntagCommand(INDEX_SECOND_PERSON, BRIDES_SIDE);
-        UntagCommand untagFirstDifferentTagCommand = new UntagCommand(INDEX_FIRST_PERSON, anotherTag);
+
+        Set<Tag> bridesSideTagSet = new HashSet<>();
+        bridesSideTagSet.add(BRIDES_SIDE);
+
+        Set<Tag> anotherTagSet = new HashSet<>();
+        anotherTagSet.add(anotherTag);
+
+        List<Index> firstIndex = new ArrayList<>();
+        firstIndex.add(INDEX_FIRST_PERSON);
+
+        List<Index> secondIndex = new ArrayList<>();
+        secondIndex.add(INDEX_SECOND_PERSON);
+
+        UntagCommand untagFirstCommand = new UntagCommand(firstIndex, bridesSideTagSet);
+        UntagCommand untagSecondCommand = new UntagCommand(secondIndex, bridesSideTagSet);
+        UntagCommand untagFirstDifferentUntagCommand = new UntagCommand(firstIndex, anotherTagSet);
 
         // same object -> returns true
         assertTrue(untagFirstCommand.equals(untagFirstCommand));
 
         // same values -> returns true
-        UntagCommand untagFirstCommandCopy = new UntagCommand(INDEX_FIRST_PERSON, BRIDES_SIDE);
+        UntagCommand untagFirstCommandCopy = new UntagCommand(firstIndex, bridesSideTagSet);
         assertTrue(untagFirstCommand.equals(untagFirstCommandCopy));
 
         // different types -> returns false
@@ -105,6 +185,6 @@ public class UntagCommandTest {
         assertFalse(untagFirstCommand.equals(untagSecondCommand));
 
         // different tag -> returns false
-        assertFalse(untagFirstCommand.equals(untagFirstDifferentTagCommand));
+        assertFalse(untagFirstCommand.equals(untagFirstDifferentUntagCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.TagCommandParser.MAX_INDEXES;
+import static seedu.address.logic.parser.TagCommandParser.MAX_LENGTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -70,7 +71,7 @@ public class TagCommandParserTest {
     public void parse_tooLongTag_throwsParseException() {
         String longTag = "veryveryveryveryveryveryveryveryveryveryverylongtagthatshouldexceedthecharacterlimit";
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + longTag;
-        String expectedMessage = Messages.MESSAGE_INPUT_LENGTH_EXCEEDED;
+        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH);
         assertParseFailure(parser, userInput, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -5,8 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.TagCommandParser.MAX_INDEXES;
-import static seedu.address.logic.parser.TagCommandParser.MAX_LENGTH;
+import static seedu.address.model.tag.Tag.MAX_CHARACTER_LENGTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -71,7 +70,7 @@ public class TagCommandParserTest {
     public void parse_tooLongTag_throwsParseException() {
         String longTag = "veryveryveryveryveryveryveryveryveryveryverylongtagthatshouldexceedthecharacterlimit";
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + longTag;
-        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH);
+        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_CHARACTER_LENGTH);
         assertParseFailure(parser, userInput, expectedMessage);
     }
 
@@ -96,6 +95,6 @@ public class TagCommandParserTest {
                 + " 10"
                 + " 11 "
                 + PREFIX_TAG + BRIDES_SIDE.getTagName();
-        assertParseFailure(parser, userInput, String.format(MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
+        assertParseFailure(parser, userInput, String.format(MESSAGE_TOO_MANY_INDEXES, Index.MAX_INDEXES));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -5,8 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.TagCommandParser.MAX_INDEXES;
-import static seedu.address.logic.parser.TagCommandParser.MAX_LENGTH;
+import static seedu.address.model.tag.Tag.MAX_CHARACTER_LENGTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -72,7 +71,7 @@ public class UntagCommandParserTest {
     public void parse_tooLongTag_throwsParseException() {
         String longTag = "veryveryveryveryveryveryveryveryveryveryverylongtagthatshouldexceedthecharacterlimit";
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + longTag;
-        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH);
+        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_CHARACTER_LENGTH);
         assertParseFailure(parser, userInput, expectedMessage);
     }
 
@@ -97,6 +96,6 @@ public class UntagCommandParserTest {
                 + " 10"
                 + " 11 "
                 + PREFIX_TAG + BRIDES_SIDE.getTagName();
-        assertParseFailure(parser, userInput, String.format(MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
+        assertParseFailure(parser, userInput, String.format(MESSAGE_TOO_MANY_INDEXES, Index.MAX_INDEXES));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -1,16 +1,29 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.TagCommandParser.MAX_INDEXES;
+import static seedu.address.logic.parser.TagCommandParser.MAX_LENGTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalTags.BRIDES_SIDE;
 import static seedu.address.testutil.TypicalTags.FRIENDS;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UntagCommand;
+import seedu.address.model.tag.Tag;
 
 public class UntagCommandParserTest {
 
@@ -19,7 +32,11 @@ public class UntagCommandParserTest {
     @Test
     public void parse_validArgs_success() {
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + FRIENDS.getTagName();
-        UntagCommand expectedCommand = new UntagCommand(INDEX_FIRST_PERSON, FRIENDS);
+        Set<Tag> tags = new HashSet<>();
+        List<Index> indexes = new ArrayList<>();
+        tags.add(FRIENDS);
+        indexes.add(INDEX_FIRST_PERSON);
+        UntagCommand expectedCommand = new UntagCommand(indexes, tags);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -39,7 +56,7 @@ public class UntagCommandParserTest {
 
     @Test
     public void parse_missingIndex_throwsParseException() {
-        String userInput = " " + PREFIX_TAG + FRIENDS;
+        String userInput = " " + PREFIX_TAG + FRIENDS.getTagName();
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE);
         assertParseFailure(parser, userInput, expectedMessage);
     }
@@ -53,9 +70,9 @@ public class UntagCommandParserTest {
 
     @Test
     public void parse_tooLongTag_throwsParseException() {
-        String longTag = "veryveryveryveryveryverylongtagthatshouldexceedthecharacterlimit";
+        String longTag = "veryveryveryveryveryveryveryveryveryveryverylongtagthatshouldexceedthecharacterlimit";
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + longTag;
-        String expectedMessage = Messages.MESSAGE_INPUT_LENGTH_EXCEEDED;
+        String expectedMessage = String.format(Messages.MESSAGE_INPUT_LENGTH_EXCEEDED, MAX_LENGTH);
         assertParseFailure(parser, userInput, expectedMessage);
     }
 
@@ -64,5 +81,22 @@ public class UntagCommandParserTest {
         String userInput = "a " + PREFIX_TAG + FRIENDS;
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE);
         assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_tooManyIndexes_throwsParseException() {
+        String userInput = INDEX_FIRST_PERSON.getOneBased() + " "
+                + INDEX_SECOND_PERSON.getOneBased() + " "
+                + INDEX_THIRD_PERSON.getOneBased()
+                + " 4"
+                + " 5"
+                + " 6"
+                + " 7"
+                + " 8"
+                + " 9"
+                + " 10"
+                + " 11 "
+                + PREFIX_TAG + BRIDES_SIDE.getTagName();
+        assertParseFailure(parser, userInput, String.format(MESSAGE_TOO_MANY_INDEXES, MAX_INDEXES));
     }
 }


### PR DESCRIPTION
- Implemented bulk untagging so that users can untag multiple guests with multiple tags at once
- Test cases are changed to test the updated UntagCommand and UntagCommandParser classes
- Messages displayed are changed to be more helpful to users

i.e. The following commands are now valid
untag 1 2 3 t/tag
untag 1 t/tag t/tag2
untag 1 2 3 t/tag t/tag2