### PR TITLE
Improve error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,9 +31,14 @@ public class DeleteTagCommand extends UndoableCommand {
 
     public static final String MESSAGE_SUCCESS = "Deleted successfully.";
     public static final String MESSAGE_SUCCESS_FORCE = "Force deleted successfully.";
+
     public static final String MESSAGE_TAGS_IN_USE = "The following tags are in use and cannot be deleted:\n%s\n"
             + "Use 'deletetag -force' to delete tags that are in use.";
-    public static final String MESSAGE_NONEXISTENT = "tag(s) have not been added before.\n";
+
+    public static final String MESSAGE_ALL_NONEXISTENT = "The following tag(s) has/have not been created before:\n";
+
+    public static final String MESSAGE_SOME_NONEXISTENT = "Existing tag(s) has/have been deleted successfully.\n"
+            + "The following tag(s) has/have not been created before:\n";
 
     private final List<Tag> tags;
     private final Map<Tag, Set<Person>> deletedSet = new HashMap<>();
@@ -52,97 +58,69 @@ public class DeleteTagCommand extends UndoableCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
-        StringBuilder errorMsg = new StringBuilder();
-        StringBuilder successMsg = new StringBuilder();
-        boolean showErrorMsg = false;
-        boolean showSuccessMsg = false;
 
-        // Check if tags exist and populate error message
-        showErrorMsg = addNonExistentTagsToError(model, errorMsg);
+        if (!isForceDelete) {
+            checkForTagsInUse(model);
+        }
 
-        // Proceed with force deletion logic
+        Set<Tag> tagsSuccessfullyDeleted = handleDelete(model);
+        return createCommandResult(tagsSuccessfullyDeleted);
+    }
+
+    /**
+     * Checks whether the tags to be deleted are currently tagged to guests (in use).
+     *
+     * @throws CommandException if any of the tags are currently in use.
+     */
+    private void checkForTagsInUse(Model model) throws CommandException {
+        Set<Tag> tagsInUse = model.getTagsInUse();
+        Set<Tag> matchingTags = tagsInUse.stream().filter(tags::contains).collect(Collectors.toSet());
+
+        if (!matchingTags.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_TAGS_IN_USE, matchingTags));
+        }
+    }
+
+    /**
+     * Generates a CommandResult message based on the success or failure of tag deletion.
+     * Determines whether to display messages for tags not successfully deleted or tags successfully deleted.
+     *
+     * @param tagsSuccessfullyDeleted Set of tags that were deleted successfully.
+     * @return A CommandResult containing the appropriate success or failure message.
+     */
+    private CommandResult createCommandResult(Set<Tag> tagsSuccessfullyDeleted) {
+        requireAllNonNull(tagsSuccessfullyDeleted);
+        List<Tag> tagsNotSuccessfullyDeleted = new ArrayList<>(tags);
+
+        // Tags that were not deleted successfully
+        tagsNotSuccessfullyDeleted.removeAll(tagsSuccessfullyDeleted);
+
+        if (!tagsNotSuccessfullyDeleted.isEmpty()) {
+            if (tagsSuccessfullyDeleted.isEmpty()) {
+                return new CommandResult(MESSAGE_ALL_NONEXISTENT + tagsNotSuccessfullyDeleted);
+            }
+            return new CommandResult(MESSAGE_SOME_NONEXISTENT + tagsNotSuccessfullyDeleted);
+        }
+
         if (isForceDelete) {
-            showSuccessMsg = deleteTagsAndSuccess(model, successMsg, MESSAGE_SUCCESS_FORCE);
-        } else {
-            // If not force delete, check for tags in use and handle accordingly
-            Set<Tag> tagsInUse = model.getTagsInUse();
-            Set<Tag> matchingTags = tagsInUse.stream().filter(tag -> tags.contains(tag)).collect(Collectors.toSet());
-
-            if (!matchingTags.isEmpty()) {
-                return new CommandResult(String.format(MESSAGE_TAGS_IN_USE, matchingTags));
-            }
-
-            // Perform standard deletion and build success message
-            showSuccessMsg = deleteTagsAndSuccess(model, successMsg, MESSAGE_SUCCESS);
+            return new CommandResult(MESSAGE_SUCCESS_FORCE);
         }
-        return constructFinalMessage(showErrorMsg, errorMsg, showSuccessMsg, successMsg);
+
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 
     /**
-     * Helper to add non-existent tags to the error message
+     * Deletes tags from the model, and removes each tag from all associated persons.
      *
-     * @param model
-     * @param errorMsg
-     * @return
+     * @param model The Model instance containing tags and persons.
+     * @return A set of tags that were successfully deleted.
      */
-    private boolean addNonExistentTagsToError(Model model, StringBuilder errorMsg) {
-        boolean hasErrors = false;
+    private Set<Tag> handleDelete(Model model) {
+        Set<Tag> tagsSuccessfullyDeleted = model.deleteTags(tags);
         for (Tag tag : tags) {
-            if (!model.hasTag(tag)) {
-                errorMsg.append(tag.toString()).append(" ");
-                hasErrors = true;
-            }
+            model.removeTagFromPersons(tag); // Remove from all persons
         }
-        if (hasErrors) {
-            errorMsg.append(MESSAGE_NONEXISTENT);
-        }
-        return hasErrors;
-    }
-
-
-    /**
-     * Helper method to delete tags and add to success message
-     *
-     * @param model
-     * @param successMsg
-     * @param successMessage
-     * @return
-     */
-    private boolean deleteTagsAndSuccess(Model model, StringBuilder successMsg, String successMessage) {
-        boolean hasSuccess = false;
-        for (Tag tag : tags) {
-            if (model.hasTag(tag)) {
-                model.deleteTags(List.of(tag)); // Remove from model tags
-                model.removeTagFromPersons(tag); // Remove from all persons
-                hasSuccess = true;
-            }
-        }
-
-        if (hasSuccess) {
-            successMsg.append(successMessage);
-        }
-        return hasSuccess;
-
-    }
-
-    /**
-     * Helper method to construct the final CommandResult message based on flags
-     *
-     * @param showErrorMsg
-     * @param errorMsg
-     * @param showSuccessMsg
-     * @param successMsg
-     * @return
-     */
-    private CommandResult constructFinalMessage(boolean showErrorMsg, StringBuilder errorMsg,
-                                                boolean showSuccessMsg, StringBuilder successMsg) {
-        if (showErrorMsg && showSuccessMsg) {
-            return new CommandResult(successMsg.toString() + " " + errorMsg.toString());
-        } else if (showErrorMsg) {
-            return new CommandResult(errorMsg.toString());
-        } else {
-            return new CommandResult(successMsg.toString());
-        }
+        return tagsSuccessfullyDeleted;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/NewtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewtagCommand.java
@@ -30,8 +30,9 @@ public class NewtagCommand extends UndoableCommand {
     public static final String MESSAGE_SOME_DUPLICATE = "Non-duplicate tag(s) has/have been created successfully.\n"
             + "The following tag(s) already exist(s):\n";
 
-    public static final String MESSAGE_TOO_MANY_TAGS = "You have more than " + TagList.MAXIMUM_TAGLIST_SIZE
-            + " tags.\nPlease remove some using 'deletetag'.\n";
+    public static final String MESSAGE_TOO_MANY_TAGS = "You are attempting to add more than "
+            + TagList.MAXIMUM_TAGLIST_SIZE + " tags in total.\n" +
+            "Please remove some using 'deletetag first'.\n";
 
     private final List<Tag> tags;
 
@@ -50,6 +51,8 @@ public class NewtagCommand extends UndoableCommand {
      *      allowable number if the new tags were to be added.
      */
     private void validateTagListSize(Model model) throws CommandException {
+        requireAllNonNull(model);
+        requireAllNonNull(tags);
         if (!model.checkAcceptableTagListSize(tags.size())) {
             throw new CommandException(MESSAGE_TOO_MANY_TAGS);
         }
@@ -60,6 +63,7 @@ public class NewtagCommand extends UndoableCommand {
      * @param model The model to which tags will be added.
      */
     private Set<Tag> addTagsToModel(Model model) {
+        requireAllNonNull(model);
         Set<Tag> tagsSuccessfullyAdded = model.addTags(tags);
         model.updateTagList();
         return tagsSuccessfullyAdded;
@@ -72,6 +76,7 @@ public class NewtagCommand extends UndoableCommand {
      * @return The corresponding CommandResult.
      */
     private CommandResult createCommandResult(Set<Tag> tagsSuccessfullyAdded) {
+        requireAllNonNull(tagsSuccessfullyAdded);
         List<Tag> tagsNotSuccessfullyAdded = new ArrayList<>(tags);
         tagsNotSuccessfullyAdded.removeAll(tagsSuccessfullyAdded);
 

--- a/src/main/java/seedu/address/logic/commands/NewtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewtagCommand.java
@@ -31,8 +31,8 @@ public class NewtagCommand extends UndoableCommand {
             + "The following tag(s) already exist(s):\n";
 
     public static final String MESSAGE_TOO_MANY_TAGS = "You are attempting to add more than "
-            + TagList.MAXIMUM_TAGLIST_SIZE + " tags in total.\n" +
-            "Please remove some using 'deletetag first'.\n";
+            + TagList.MAXIMUM_TAGLIST_SIZE + " tags in total.\n"
+            + "Please remove some using 'deletetag first'.\n";
 
     private final List<Tag> tags;
 

--- a/src/main/java/seedu/address/logic/commands/NewtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewtagCommand.java
@@ -25,7 +25,7 @@ public class NewtagCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " t/bride's side t/groom's side";
 
     public static final String MESSAGE_SUCCESS = "New tag(s) created.\n";
-    public static final String MESSAGE_ALL_DUPLICATE = "The following tag(s) already exist:\n";
+    public static final String MESSAGE_ALL_DUPLICATE = "The following tag(s) already exist(s):\n";
 
     public static final String MESSAGE_SOME_DUPLICATE = "Non-duplicate tag(s) has/have been created successfully.\n"
             + "The following tag(s) already exist(s):\n";

--- a/src/main/java/seedu/address/logic/commands/NewtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewtagCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -23,8 +25,11 @@ public class NewtagCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " t/bride's side t/groom's side";
 
     public static final String MESSAGE_SUCCESS = "New tag(s) created.\n";
-    public static final String MESSAGE_DUPLICATE = "Some tag(s) already exist(s).\n"
-            + "Non-duplicate tags (if any) have been added successfully.\n";
+    public static final String MESSAGE_ALL_DUPLICATE = "The following tag(s) already exist:\n";
+
+    public static final String MESSAGE_SOME_DUPLICATE = "Non-duplicate tag(s) has/have been created successfully.\n"
+            + "The following tag(s) already exist(s):\n";
+
     public static final String MESSAGE_TOO_MANY_TAGS = "You have more than " + TagList.MAXIMUM_TAGLIST_SIZE
             + " tags.\nPlease remove some using 'deletetag'.\n";
 
@@ -54,21 +59,27 @@ public class NewtagCommand extends UndoableCommand {
      * Adds the tags to the model and checks for duplicates.
      * @param model The model to which tags will be added.
      */
-    private boolean addTagsToModel(Model model) {
-        boolean isSuccessful = model.addTags(tags);
+    private Set<Tag> addTagsToModel(Model model) {
+        Set<Tag> tagsSuccessfullyAdded = model.addTags(tags);
         model.updateTagList();
-        return isSuccessful;
+        return tagsSuccessfullyAdded;
     }
 
     /**
      * Creates a CommandResult based on the success of adding tags to the model.
      *
-     * @param isSuccessful Indicates if the tags were successfully added.
+     * @param tagsSuccessfullyAdded the tags that were successfully added.
      * @return The corresponding CommandResult.
      */
-    private CommandResult createCommandResult(boolean isSuccessful) {
-        if (!isSuccessful) {
-            return new CommandResult(MESSAGE_DUPLICATE);
+    private CommandResult createCommandResult(Set<Tag> tagsSuccessfullyAdded) {
+        List<Tag> tagsNotSuccessfullyAdded = new ArrayList<>(tags);
+        tagsNotSuccessfullyAdded.removeAll(tagsSuccessfullyAdded);
+
+        if (!tagsNotSuccessfullyAdded.isEmpty()) {
+            if (tagsSuccessfullyAdded.isEmpty()) {
+                return new CommandResult(MESSAGE_ALL_DUPLICATE + tagsNotSuccessfullyAdded);
+            }
+            return new CommandResult(MESSAGE_SOME_DUPLICATE + tagsNotSuccessfullyAdded);
         }
         return new CommandResult(MESSAGE_SUCCESS);
     }
@@ -77,8 +88,8 @@ public class NewtagCommand extends UndoableCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
         validateTagListSize(model);
-        boolean isSuccessful = addTagsToModel(model);
-        return createCommandResult(isSuccessful);
+        Set<Tag> tagsSuccessfullyAdded = addTagsToModel(model);
+        return createCommandResult(tagsSuccessfullyAdded);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RenameTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameTagCommand.java
@@ -2,10 +2,6 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,15 +107,15 @@ public interface Model {
     boolean addTag(Tag tag);
 
     /**
-     * Adds a tag to the tag list.
+     * Adds a variable number of tags to the tag list.
      *
      * @param tags The tags to be added.
-     * @return true if all tags were successfully added, false if any tag already exists.
+     * @return the set of tags which were added successfully (could be none).
      */
-    boolean addTags(List<Tag> tags);
+    Set<Tag> addTags(List<Tag> tags);
 
     /**
-     * Deletes a tag from the tag list.
+     * Deletes a variable number of tags from the tag list.
      * @param tag The tag to be deleted
      * @return true if the tag was successfully deleted, false if the tag does not exist.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -122,12 +122,12 @@ public interface Model {
     boolean deleteTag(Tag tag);
 
     /**
-     * Deletes a tag from the tag list.
+     * Deletes a variable number of tags from the tag list.
      *
      * @param tags The tags to be deleted.
-     * @return true if the tag was successfully deleted, false if the tag does not exist.
+     * @return the set of tags which were deleted successfully (could be none).
      */
-    boolean deleteTags(List<Tag> tags);
+    Set<Tag> deleteTags(List<Tag> tags);
 
     /**
      * Renames a tag from the tag list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -185,7 +185,7 @@ public class ModelManager implements Model {
     public boolean deleteTags(List<Tag> tags) {
         boolean isSuccessful = true;
         for (Tag tag : tags) {
-            isSuccessful &= addressBook.deleteTag(tag);
+            isSuccessful &= deleteTag(tag);
         }
         return isSuccessful;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -166,12 +166,15 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean addTags(List<Tag> tags) {
-        boolean isSuccessful = true;
+    public Set<Tag> addTags(List<Tag> tags) {
+        Set<Tag> tagsSuccessfullyAdded = new HashSet<>();
         for (Tag tag : tags) {
-            isSuccessful &= addressBook.addTag(tag);
+            boolean isSuccessful = addressBook.addTag(tag);
+            if (isSuccessful) {
+                tagsSuccessfullyAdded.add(tag);
+            }
         }
-        return isSuccessful;
+        return tagsSuccessfullyAdded;
     }
 
     @Override public boolean deleteTag(Tag tag) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -169,7 +169,7 @@ public class ModelManager implements Model {
     public Set<Tag> addTags(List<Tag> tags) {
         Set<Tag> tagsSuccessfullyAdded = new HashSet<>();
         for (Tag tag : tags) {
-            boolean isSuccessful = addressBook.addTag(tag);
+            boolean isSuccessful = addTag(tag);
             if (isSuccessful) {
                 tagsSuccessfullyAdded.add(tag);
             }
@@ -182,12 +182,15 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean deleteTags(List<Tag> tags) {
-        boolean isSuccessful = true;
+    public Set<Tag> deleteTags(List<Tag> tags) {
+        Set<Tag> tagsSuccessfullyDeleted = new HashSet<>();
         for (Tag tag : tags) {
-            isSuccessful &= deleteTag(tag);
+            boolean isSuccessful = deleteTag(tag);
+            if (isSuccessful) {
+                tagsSuccessfullyDeleted.add(tag);
+            }
         }
-        return isSuccessful;
+        return tagsSuccessfullyDeleted;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -196,7 +196,7 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public boolean addTags(List<Tag> tags) {
+        public Set<Tag> addTags(List<Tag> tags) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -206,7 +206,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean deleteTags(List<Tag> tag) {
+        public Set<Tag> deleteTags(List<Tag> tag) {
             throw new AssertionError("This method should not be called.");
         }
         @Override

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -25,7 +25,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.TypicalTags;
 
 /**
  * Contains tests for DeleteTagCommand.

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_SOME_NONEXISTENT;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalTags.BRIDES_SIDE;
 import static seedu.address.testutil.TypicalTags.COLLEAGUES;
@@ -79,7 +81,7 @@ public class DeleteTagCommandTest {
         List<Tag> nonExistentTags = List.of(nonExistentTag);
 
         DeleteTagCommand newTagCommand = new DeleteTagCommand(nonExistentTags, false);
-        String expectedMessage = BRIDES_SIDE + " " + DeleteTagCommand.MESSAGE_NONEXISTENT;
+        String expectedMessage = DeleteTagCommand.MESSAGE_ALL_NONEXISTENT + nonExistentTags;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
@@ -98,8 +100,7 @@ public class DeleteTagCommandTest {
         model.addTag(existingTag);
 
         DeleteTagCommand newTagCommand = new DeleteTagCommand(mixedTags, false);
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS + " " + FRIENDS + " " + COLLEAGUES
-                + " " + DeleteTagCommand.MESSAGE_NONEXISTENT;
+        String expectedMessage = MESSAGE_SOME_NONEXISTENT + List.of(newFriendsTag, newColleaguesTag);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addTags(mixedTags);
@@ -145,8 +146,7 @@ public class DeleteTagCommandTest {
 
         String expectedMessage = String.format(DeleteTagCommand.MESSAGE_TAGS_IN_USE, model.getTagsInUse());
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -3,7 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_ALL_NONEXISTENT;
 import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_SOME_NONEXISTENT;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_SUCCESS_FORCE;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_TAGS_IN_USE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalTags.BRIDES_SIDE;
 import static seedu.address.testutil.TypicalTags.COLLEAGUES;
@@ -48,7 +52,7 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS;
+        String expectedMessage = MESSAGE_SUCCESS;
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
     }
@@ -67,7 +71,7 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS;
+        String expectedMessage = MESSAGE_SUCCESS;
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
     }
@@ -81,7 +85,7 @@ public class DeleteTagCommandTest {
         List<Tag> nonExistentTags = List.of(nonExistentTag);
 
         DeleteTagCommand newTagCommand = new DeleteTagCommand(nonExistentTags, false);
-        String expectedMessage = DeleteTagCommand.MESSAGE_ALL_NONEXISTENT + nonExistentTags;
+        String expectedMessage = MESSAGE_ALL_NONEXISTENT + nonExistentTags;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
@@ -93,9 +97,9 @@ public class DeleteTagCommandTest {
      */
     @Test
     public void execute_mixedExistingAndNonExistentTags_withError() {
-        Tag existingTag = TypicalTags.BRIDES_SIDE;
-        Tag newColleaguesTag = TypicalTags.COLLEAGUES;
-        Tag newFriendsTag = TypicalTags.FRIENDS;
+        Tag existingTag = BRIDES_SIDE;
+        Tag newColleaguesTag = COLLEAGUES;
+        Tag newFriendsTag = FRIENDS;
         List<Tag> mixedTags = List.of(newFriendsTag, existingTag, newColleaguesTag);
         model.addTag(existingTag);
 
@@ -124,7 +128,7 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS_FORCE;
+        String expectedMessage = MESSAGE_SUCCESS_FORCE;
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
     }
@@ -144,7 +148,7 @@ public class DeleteTagCommandTest {
 
         DeleteTagCommand deleteTagCommand = new DeleteTagCommand(List.of(existingTag), false);
 
-        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_TAGS_IN_USE, model.getTagsInUse());
+        String expectedMessage = String.format(MESSAGE_TAGS_IN_USE, model.getTagsInUse());
 
         assertCommandFailure(deleteTagCommand, model, expectedMessage);
     }
@@ -156,7 +160,7 @@ public class DeleteTagCommandTest {
     public void execute_tagInUseForceDelete_success() {
         // Arrange
         // Set up the existing tag and associate it with ALICE
-        Tag existingTag = TypicalTags.BRIDES_SIDE;
+        Tag existingTag = BRIDES_SIDE;
         Person aliceWithTag = new Person(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(),
                 ALICE.getRsvpStatus(), Set.of(existingTag));
 
@@ -171,7 +175,7 @@ public class DeleteTagCommandTest {
         expectedModel.setPerson(aliceWithTag, new Person(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(),
                 ALICE.getRsvpStatus(), Set.of())); // ALICE with tag removed
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS_FORCE;
+        String expectedMessage = MESSAGE_SUCCESS_FORCE;
 
         // Act & Assert
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
@@ -190,7 +194,7 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        String expectedMessage = DeleteTagCommand.MESSAGE_SUCCESS;
+        String expectedMessage = MESSAGE_SUCCESS;
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/NewtagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NewtagCommandTest.java
@@ -69,7 +69,7 @@ public class NewtagCommandTest {
         model.addTags(duplicateTags);
 
         NewtagCommand newTagCommand = new NewtagCommand(duplicateTags);
-        String expectedMessage = NewtagCommand.MESSAGE_DUPLICATE;
+        String expectedMessage = NewtagCommand.MESSAGE_ALL_DUPLICATE + duplicateTags;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addTags(duplicateTags);
@@ -87,7 +87,7 @@ public class NewtagCommandTest {
         model.addTag(duplicateTag);
 
         NewtagCommand newTagCommand = new NewtagCommand(mixedTags);
-        String expectedMessage = NewtagCommand.MESSAGE_DUPLICATE;
+        String expectedMessage = NewtagCommand.MESSAGE_SOME_DUPLICATE + List.of(duplicateTag);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addTags(mixedTags);

--- a/src/test/java/seedu/address/logic/commands/RenameTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RenameTagCommandTest.java
@@ -2,7 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.RenameTagCommand.MESSAGE_NONEXISTENT_OR_DUPLICATE;
+import static seedu.address.logic.commands.RenameTagCommand.MESSAGE_DUPLICATE;
+import static seedu.address.logic.commands.RenameTagCommand.MESSAGE_NONEXISTENT;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,7 @@ public class RenameTagCommandTest {
     public void execute_nonExistentTagToNonExistentNewTag_failure() {
         Tag newTag = new Tag(TYPICAL_NAME);
         RenameTagCommand renameTagCommand = new RenameTagCommand(newTag, NEW_NAME);
-        String expectedMessage = MESSAGE_NONEXISTENT_OR_DUPLICATE;
+        String expectedMessage = MESSAGE_NONEXISTENT + newTag;
         assertCommandFailure(renameTagCommand, model, expectedMessage);
     }
 
@@ -43,8 +44,9 @@ public class RenameTagCommandTest {
         Tag existingTag = new Tag(NEW_NAME);
         model.addTag(existingTag);
         Tag newTag = new Tag(TYPICAL_NAME);
+        model.addTag(newTag);
         RenameTagCommand renameTagCommand = new RenameTagCommand(newTag, NEW_NAME);
-        String expectedMessage = MESSAGE_NONEXISTENT_OR_DUPLICATE;
+        String expectedMessage = MESSAGE_DUPLICATE + existingTag;
         assertCommandFailure(renameTagCommand, model, expectedMessage);
     }
 


### PR DESCRIPTION
- newtag now notifies users of which tags failed to be added
- deletetag now notifies users of which tags failed to be deleted
- renametag now notifies users of the type of error causing it to fail